### PR TITLE
Return void for all events

### DIFF
--- a/src/Entry/EntryObserver.php
+++ b/src/Entry/EntryObserver.php
@@ -94,8 +94,6 @@ class EntryObserver extends Observer
         //$entry->fireFieldTypeEvents('entry_saving');
 
         $this->commands->dispatch(new SetMetaInformation($entry));
-
-        return true;
     }
 
     /**
@@ -120,8 +118,6 @@ class EntryObserver extends Observer
     public function deleting(EntryInterface $entry)
     {
         $this->dispatch(new CascadeDelete($entry));
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
Returning a non-void value was causing issues with venturecraft/revisionable and is unneeded for any Pyro functionality.